### PR TITLE
Improve Direct Line resilience and add CI validation

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-cliff-0d801a31e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-cliff-0d801a31e.yml
@@ -19,12 +19,14 @@ jobs:
         with:
           submodules: true
           lfs: false
+      - name: Run validation tests
+        run: npm test
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_CLIFF_0D801A31E }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# SchauenLink Assistant Page
+
+This repository hosts the static client for the SchauenLink assistant powered by the Bot Framework Web Chat widget.
+
+## Local development
+
+The page requires a Direct Line token issued by the SchauenLink backend. By default the client requests a token from:
+
+```
+https://schauenlink.com/api/directline/token
+```
+
+For local development you can expose your own Direct Line endpoint by updating the fetch URL in `index.html` or by proxying the hosted API. Ensure the endpoint responds to a `POST` request with a JSON payload containing a `token` property:
+
+```json
+{ "token": "<DIRECT_LINE_TOKEN>" }
+```
+
+## Tests
+
+Run the lightweight HTML validation script before committing to verify critical elements are present:
+
+```bash
+npm test
+```
+
+The same check runs automatically in CI before the site is deployed.

--- a/index.html
+++ b/index.html
@@ -15,27 +15,76 @@
       height: 100%;
       width: 100%;
     }
+
+    #webchat-status {
+      position: absolute;
+      top: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #fff3cd;
+      color: #664d03;
+      border: 1px solid #ffeeba;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+      max-width: 90%;
+      display: none;
+    }
   </style>
 </head>
 <body>
+  <div id="webchat-status" role="status" aria-live="polite"></div>
   <div id="webchat"></div>
 
   <script>
-    async function fetchDirectLineToken() {
-      const response = await fetch('https://schauenlink.com/api/directline/token', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+    const statusElement = document.getElementById('webchat-status');
 
-      const { token } = await response.json();
-      return token;
+    function showStatus(message, { isError = false } = {}) {
+      if (!statusElement) return;
+
+      statusElement.textContent = message;
+      statusElement.style.display = message ? 'block' : 'none';
+      statusElement.style.background = isError ? '#f8d7da' : '#fff3cd';
+      statusElement.style.color = isError ? '#842029' : '#664d03';
+      statusElement.style.borderColor = isError ? '#f5c2c7' : '#ffeeba';
+    }
+
+    async function fetchDirectLineToken() {
+      try {
+        const response = await fetch('https://schauenlink.com/api/directline/token', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const { token } = await response.json();
+
+        if (!token) {
+          throw new Error('Token missing from response payload');
+        }
+
+        return token;
+      } catch (error) {
+        console.error('Failed to fetch Direct Line token', error);
+        showStatus('We\'re having trouble connecting to the assistant. Please try again later.', { isError: true });
+        return null;
+      }
     }
 
     (async () => {
+      showStatus('Connecting to the assistant…');
       const directLineToken = await fetchDirectLineToken();
-      if (!directLineToken) return;
+
+      if (!directLineToken) {
+        return;
+      }
+
+      showStatus('');
 
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ token: directLineToken }),

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "assistant-page",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node scripts/check-html.js"
+  }
+}

--- a/scripts/check-html.js
+++ b/scripts/check-html.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const htmlPath = path.resolve(__dirname, '..', 'index.html');
+
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+const requiredSnippets = [
+  'id="webchat"',
+  'id="webchat-status"',
+  'renderWebChat',
+  'Connecting to the assistant…'
+];
+
+const missing = requiredSnippets.filter((snippet) => !html.includes(snippet));
+
+if (missing.length) {
+  console.error('HTML validation failed. Missing snippets:', missing.join(', '));
+  process.exit(1);
+}
+
+console.log('HTML validation passed.');


### PR DESCRIPTION
## Summary
- add user-facing status messaging and robust error handling when requesting the Direct Line token
- document how to configure the Direct Line endpoint locally and add a lightweight HTML validation test
- run the new validation test during CI before deploying the static web app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e28b7164108330b2995b8167da7b0d